### PR TITLE
Implement copyAIInstallerToAlpine function

### DIFF
--- a/mobile/android/app/src/main/java/com/spiralgang/weblabs/utils/AlpineLinuxInstaller.kt
+++ b/mobile/android/app/src/main/java/com/spiralgang/weblabs/utils/AlpineLinuxInstaller.kt
@@ -45,8 +45,7 @@ class AlpineLinuxInstaller(private val context: Context) {
             setupBasicEnvironment()
             
             // Copy AI model installer script to Alpine environment
-            // TODO: Implement copyAIInstallerToAlpine(alpineRoot)
-            // copyAIInstallerToAlpine(alpineRoot)
+            copyAIInstallerToAlpine(alpineRoot)
             
             Log.i(TAG, "Alpine Linux installation completed successfully")
             
@@ -250,6 +249,29 @@ class AlpineLinuxInstaller(private val context: Context) {
         }
     }
     
+    private suspend fun copyAIInstallerToAlpine(destDir: File) = withContext(Dispatchers.IO) {
+        Log.i(TAG, "Copying AI model installer script to Alpine environment...")
+
+        val installerName = "alpine_ai_model_installer.sh"
+        val destFile = File(destDir, "home/developer/$installerName")
+
+        try {
+            // Ensure destination directory exists
+            destFile.parentFile?.mkdirs()
+
+            context.assets.open(installerName).use { input ->
+                FileOutputStream(destFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            destFile.setExecutable(true)
+            Log.i(TAG, "AI model installer script copied to ${destFile.absolutePath}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to copy AI model installer script", e)
+            throw e
+        }
+    }
+
     suspend fun setupDevelopmentEnvironment() = withContext(Dispatchers.IO) {
         Log.i(TAG, "Setting up development environment...")
         


### PR DESCRIPTION
This PR implements the `copyAIInstallerToAlpine` function in `AlpineLinuxInstaller.kt` as requested. 

Key changes:
1.  **Implemented `copyAIInstallerToAlpine`**: This function copies `alpine_ai_model_installer.sh` from the Android assets to `home/developer/alpine_ai_model_installer.sh` within the Alpine Linux root directory.
2.  **Robustness**: Added a call to `mkdirs()` on the destination parent directory to ensure it exists before the copy operation.
3.  **Permissions**: Correctly sets the executable bit on the copied script using `setExecutable(true)`.
4.  **Integration**: Uncommented the call to `copyAIInstallerToAlpine(alpineRoot)` in the main `downloadAndInstallAlpine` function to enable this step in the installation process.

Verified the implementation by reviewing the code and ensuring it aligns with the existing patterns in the `AlpineLinuxInstaller` class.

---
*PR created automatically by Jules for task [14696442707022894873](https://jules.google.com/task/14696442707022894873) started by @spiralgang*